### PR TITLE
Disable SymbolArray and WordArray

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -27,12 +27,6 @@ Style/StringLiterals:
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: single_quotes
 
-Style/SymbolArray:
-  Enabled: true
-
 Style/TrailingCommaInLiteral:
   Enabled: true
   EnforcedStyleForMultiline: no_comma
-
-Style/WordArray:
-  Enabled: true


### PR DESCRIPTION
### Background

```ruby
permit_params :foo :bar, baz: [:hoge, :fuga, :piyo]
```

will be corrected to:

```ruby
permit_params :foo :bar, baz: %i(hoge fuga piyo)
```

It looks ugly a little :sob:

So I want to disable them..!
(Note that onkcop disables them because hard to distinguish `%w` and `%i`.)