### PR TITLE
Disable the RSpec/DescribedClass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # rubocop-codetakt
 
+## v0.4.0 (2017-04-07)
+
+[full changelog](https://github.com/codetakt/rubocop-codetakt/compare/v0.3.0...v0.4.0)
+
+* Disable the Style/WordArray cop and the Style/SymbolArray cop.
+
 ## v0.3.0 (2017-04-03)
 
 [full changelog](https://github.com/codetakt/rubocop-codetakt/compare/v0.2.3...v0.3.0)

--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -1,3 +1,7 @@
 inherit_gem:
   onkcop:
     - config/rspec.yml
+
+RSpec/DescribedClass:
+  Exclude:
+    - "spec/requests/*"


### PR DESCRIPTION
Request specs does not target the Ruby classes.