### PR TITLE
Loosen RSpec/NestedGroups to Max: 4

### DIFF
--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -13,3 +13,8 @@ RSpec/DescribedClass:
 #         context 'smaller scope (parameter)'
 RSpec/NestedGroups:
   Max: 4
+
+# TODO: Remove after below PR is released.
+# https://github.com/onk/onkcop/pull/30
+RSpec/EmptyLineAfterFinalLet:
+  Enabled: false

--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -5,3 +5,11 @@ inherit_gem:
 RSpec/DescribedClass:
   Exclude:
     - "spec/requests/*"
+
+# Accepts more deeper nests than default(3).
+#   describe 'Class'
+#     describe 'method'
+#       context 'larger scope (behavior)'
+#         context 'smaller scope (parameter)'
+RSpec/NestedGroups:
+  Max: 4


### PR DESCRIPTION
RSpec/NestedGroups is set to `Max: 3` by default, but I feel it's too strict.
Also backports https://github.com/onk/onkcop/pull/30.