### PR TITLE
Adapt to separating of TrailingCommaInLiteral rule

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -36,5 +36,8 @@ Style/StringLiteralsInInterpolation:
 Style/TrailingCommaInArguments:
   Enabled: false
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+
+Style/TrailingCommaInHashLiteral:
   Enabled: false


### PR DESCRIPTION
See:
https://github.com/bbatsov/rubocop/pull/5307
https://github.com/bbatsov/rubocop/pull/5405