### PR TITLE
Can adopt newer rubocop

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -36,5 +36,8 @@ Style/StringLiteralsInInterpolation:
 Style/TrailingCommaInArguments:
   Enabled: false
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+
+Style/TrailingCommaInHashLiteral:
   Enabled: false

--- a/rubocop-codetakt.gemspec
+++ b/rubocop-codetakt.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.files       = Dir['CHANGELOG.md', 'README.md', 'LICENSE', 'config/*.yml']
 
-  s.add_dependency 'onkcop', '0.52.1.1'
+  s.add_dependency "onkcop", ">= 0.53.0"
 
   s.add_development_dependency 'bundler', '~> 1.14'
   s.add_development_dependency 'rake',    '~> 10.0'


### PR DESCRIPTION
* [x] b1ff7a7 Can use the newer RuboCop with onkcop 

* [x] 3ffdcdd Follow the division separation of the cops 
