### PR TITLE
RSpec/MultipleExpectationsをoffにした

### DIFF
--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -40,14 +40,12 @@ RSpec/ImplicitExpect:
 RSpec/InstanceVariable:
   Enabled: false
 
-# spec_helper で meta[:aggregate_failures] を設定することで
-# aggregate_failures が全ての spec で有効になる。
-#
-# ほぼ MultipleExpectations についてはチェックされなくなる設定なので注意。
-# パフォーマンスの問題さえ無ければ 1 example 1 assertion にしておく方が
-# 読みやすいテストになりやすいので、そこはレビューで担保していく必要がある。
+# rubocop-rspec v1.34.0 から RSpec/MultipleExpectations の AggregateFailuresByDefault オプションがなくなった
+# https://github.com/rubocop-hq/rubocop-rspec/blob/v1.34.0/CHANGELOG.md
+# feature specなどでは1つのitに複数のexpectをよく書く
+# 弊社ではaggregate_failuresをデフォルトで有効にしているのでこのCopをoffにする
 RSpec/MultipleExpectations:
-  AggregateFailuresByDefault: true
+  Enabled: false
 
 # 変に名前つけて呼ぶ方が分かりづらい。
 # テスト対象メソッドを呼ぶだけの subject 以外を書かないようにする方が効く。


### PR DESCRIPTION
rubocop-rspec v1.34.0 から RSpec/MultipleExpectations の AggregateFailuresByDefault オプションがなくなった
https://github.com/rubocop-hq/rubocop-rspec/blob/v1.34.0/CHANGELOG.md
feature specなどでは1つのitに複数のexpectをよく書く
弊社でははaggregate_failuresをデフォルトで有効にしているのでこのCopをoffにする
https://realtime-lms.slack.com/archives/C1UQM221M/p1591056517109000