### PR TITLE
Bump version to v0.93.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # rubocop-codetakt:
 
-## unreleased
+## v0.93.1.0 (2020-11-02)
 
-* Update `rubocop-performance` v1.8.1, `rubocop-rails` v2.8.1 and `rubocop-rspec` v1.44.1
+* Update `rubocop` v0.93.1, `rubocop-performance` v1.8.1, `rubocop-rails` v2.8.1 and `rubocop-rspec` v1.44.1
 
 ## v0.90.0.0 (2020-09-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # rubocop-codetakt:
 
+## unreleased
+
+* Update `rubocop-performance` v1.8.1, `rubocop-rails` v2.8.1 and `rubocop-rspec` v1.44.1
+
 ## v0.90.0.0 (2020-09-01)
 
 * Update `rubocop` to v0.90.0

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,6 @@ gemspec
 
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.0'
-gem 'rubocop-performance', '~> 1.7.0'
-gem 'rubocop-rails', '~> 2.6.0'
-gem 'rubocop-rspec', '~> 1.41.0'
+gem 'rubocop-performance', '~> 1.8.0'
+gem 'rubocop-rails', '~> 2.8.0'
+gem 'rubocop-rspec', '~> 1.44.0'

--- a/lib/rubocop/codetakt/version.rb
+++ b/lib/rubocop/codetakt/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Codetakt
-    VERSION = '0.90.0.0'.freeze
+    VERSION = '0.93.1.0'.freeze
   end
 end

--- a/rubocop-codetakt.gemspec
+++ b/rubocop-codetakt.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) {|f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.90.0'
+  spec.add_dependency 'rubocop', '~> 0.93.1'
 end


### PR DESCRIPTION
* [x] 67c7e3d Update rubocop-performance v1.8.1, rubocop-rails v2.8.1 and rubocop-rspec v1.44.1 

* [x] feb9229 Bump version to v0.93.1.0 

    We didn't adopt RuboCop v1.1 either v1.0 now, because rubocop-rspec doesn't support v1.x yet.

    See: <https://github.com/rubocop-hq/rubocop-rspec/issues/1051>
