### PR TITLE
Update config: require → plugins

### DIFF
--- a/config/performance.yml
+++ b/config/performance.yml
@@ -1,4 +1,5 @@
-require: "rubocop-performance"
+plugins:
+  - rubocop-performance
 
 # downcase or upcase しての比較はイディオムの域なので、多少の
 # パフォーマンスの違いがあろうが casecmp に変える意義を感じない

--- a/config/rails.yml
+++ b/config/rails.yml
@@ -1,4 +1,5 @@
-require: "rubocop-rails"
+plugins:
+  - rubocop-rails
 
 Rails:
   Enabled: true

--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -1,4 +1,5 @@
-require: "rubocop-rspec"
+plugins:
+  - rubocop-rspec
 
 # 日本語だと「〜の場合」になるので suffix でないと対応できない
 RSpec/ContextWording:


### PR DESCRIPTION
```
rubocop-performance extension supports plugin, specify `plugins: rubocop-performance` instead of `require: rubocop-performance` in /nix/store/rccdlpvlrdlqli50h61ib1zi20skhpz7-calenadr-service-ruby-env/lib/ruby/gems/3.4.0/gems/rubocop-codetakt-1.25.1.1/config/performance.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

rubocop-rails extension supports plugin, specify `plugins: rubocop-rails` instead of `require: rubocop-rails` in /nix/store/rccdlpvlrdlqli50h61ib1zi20skhpz7-calenadr-service-ruby-env/lib/ruby/gems/3.4.0/gems/rubocop-codetakt-1.25.1.1/config/rails.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

rubocop-rspec extension supports plugin, specify `plugins: rubocop-rspec` instead of `require: rubocop-rspec` in /nix/store/rccdlpvlrdlqli50h61ib1zi20skhpz7-calenadr-service-ruby-env/lib/ruby/gems/3.4.0/gems/rubocop-codetakt-1.25.1.1/config/rspec.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
```